### PR TITLE
Use mailcatcher for email testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains Docker configuration aimed at Moodle developers and tes
 ## Features:
 * All supported database servers (PostgreSQL, MySQL, Micosoft SQL Server, Oracle XE)
 * Behat/Selenium configuration for Firefox and Chrome
+* Catch-all smtp server and web interface to messages using [mailcatcher](https://github.com/sj26/mailcatcher/)
 * All PHP Extensions enabled configured for external services (e.g. solr, ldap)
 * All supported PHP versions
 * Zero-configuration approach
@@ -51,6 +52,10 @@ bin/moodle-docker-compose exec webserver php admin/cli/install_database.php --ag
 # Shut down containers
 bin/moodle-docker-compose down
 ```
+
+## Manual testing
+
+Moodle is configured to listen on `http://localhost:8000/` and mailcatcher is listening on `http://localhost:2525/` to view emails which Moodle has sent out.
 
 ## Branching Model
 

--- a/base.yml
+++ b/base.yml
@@ -6,6 +6,7 @@ services:
       - "8000:80"
     depends_on:
       - db
+      - mail
     volumes:
       - "${MOODLE_DOCKER_WWWROOT}:/var/www/html"
     environment:
@@ -24,3 +25,7 @@ services:
     image: selenium/standalone-firefox:2.53.1
     volumes:
       - "${MOODLE_DOCKER_WWWROOT}:/var/www/html:ro"
+  mail:
+    image: tophfr/mailcatcher
+    ports:
+      - "2525:80"

--- a/config.docker-template.php
+++ b/config.docker-template.php
@@ -17,6 +17,7 @@ $CFG->wwwroot   = 'http://localhost:8000';
 $CFG->dataroot  = '/var/www/moodledata';
 $CFG->admin     = 'admin';
 $CFG->directorypermissions = 0777;
+$CFG->smtphosts = 'mail';
 
 $CFG->phpunit_dataroot  = '/var/www/moodledata/phpunit';
 $CFG->phpunit_prefix = 't_';


### PR DESCRIPTION
This could be an optional depdency, but I think the simplicity benefits
of having it run by default are worthwhile. (Can be changed in future to
be disabled, or replaced with a more eleborate smtp setup).

Fixes #28